### PR TITLE
updated versions to 2.5 and pull from dockerhub not bintray

### DIFF
--- a/ssl-certs/hybrid/README.md
+++ b/ssl-certs/hybrid/README.md
@@ -2,12 +2,12 @@
 
 Place the hybrid deployment certificiates here (cluster.key and cluster.crt)
 
-See here for info on creating cluster certificates; https://docs.konghq.com/enterprise/2.1.x/deployment/hybrid-mode-setup/#step-1-generate-a-certificatekey-pair
+See here for info on creating cluster certificates; https://docs.konghq.com/enterprise/2.5.x/deployment/hybrid-mode-setup/#step-1-generate-a-certificatekey-pair
 
 To create the certificates, you can start a temporary kong container using a command as below (this maps the repository directory to the container which allows the certificates to be saved to the docker host);
 
 ```
-docker run --rm -it --user root -v $(pwd)/ssl-certs/hybrid:/tmp/ssl/hybrid kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition:2.2.0.0-alpine /bin/sh
+docker run --rm -it --user root -v $(pwd)/ssl-certs/hybrid:/tmp/ssl/hybrid kong:2.5.0-alpine /bin/sh
 ```
 
 Then run;


### PR DESCRIPTION
these could also be set to latest and latest alpine...

```
See here for info on creating cluster certificates; https://docs.konghq.com/enterprise/latest/deployment/hybrid-mode-setup/#step-1-generate-a-certificatekey-pair
```

```
docker run --rm -it --user root -v $(pwd)/ssl-certs/hybrid:/tmp/ssl/hybrid kong:alpine /bin/sh
```

if you prefer