### PR TITLE
[fix] #12 kong-cp & kong-dp failing to start

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -167,8 +167,8 @@ services:
       KONG_ADMIN_GUI_HEADER_TXT: "*** Support environment ***"
       KONG_ADMIN_GUI_HEADER_BG_COLOR: "green"
       KONG_ADMIN_GUI_HEADER_TXT_COLOR: "white"
-      #KONG_PLUGINS: "bundled"
-      KONG_PLUGINS: "bundled, custom-handler"
+      KONG_PLUGINS: "bundled"
+      #KONG_PLUGINS: "bundled, custom-handler"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s
@@ -237,7 +237,8 @@ services:
       KONG_REAL_IP_RECURSIVE: "on"
       KONG_DATA_PLANE_CONFIG_CACHE_PATH: "/tmp/kong_config/config.cache.json.gz"
 #      KONG_NGINX_PROXY_LUA_TRANSFORM_UNDERSCORES_IN_RESPONSE_HEADERS: "off"
-      KONG_PLUGINS: "bundled, custom-handler"
+      KONG_PLUGINS: "bundled"
+      #KONG_PLUGINS: "bundled, custom-handler"
     healthcheck:
       test: ["CMD", "kong", "health"]
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
       - ./tracing:/usr/local/kong/tracing
       - ./http_content:/tmp/htdocs
 #      - ../kong-plugin-log-filter/kong/plugins/log-filter:/usr/local/share/lua/5.1/kong/plugins/log-filter
-      - ../kong-plugin-custom-handler/kong/plugins/custom-handler:/usr/local/share/lua/5.1/kong/plugins/custom-handler
+#      - ../kong-plugin-custom-handler/kong/plugins/custom-handler:/usr/local/share/lua/5.1/kong/plugins/custom-handler
     environment:
       KONG_PROXY_LISTEN: "off"
       KONG_ADMIN_LISTEN: "0.0.0.0:48001, 0.0.0.0:48444 http2 ssl"
@@ -199,7 +199,7 @@ services:
       - ./tracing:/usr/local/kong/tracing
       - ./config:/tmp/kong_config
 #      - ../kong-plugin-log-filter/kong/plugins/log-filter:/usr/local/share/lua/5.1/kong/plugins/log-filter
-      - ../kong-plugin-custom-handler/kong/plugins/custom-handler:/usr/local/share/lua/5.1/kong/plugins/custom-handler
+#      - ../kong-plugin-custom-handler/kong/plugins/custom-handler:/usr/local/share/lua/5.1/kong/plugins/custom-handler
     environment:
       KONG_ADMIN_LISTEN: "0.0.0.0:48001, 0.0.0.0:48444 http2 ssl reuseport backlog=65536"
       KONG_PROXY_LISTEN: "0.0.0.0:48000, 0.0.0.0:48443 http2 ssl reuseport backlog=65536"


### PR DESCRIPTION
Changed `KONG_PLUGINS` to bundled to enable kong-cp and kong-dp services to start. Addresses #12 