### PR TITLE
Update haproxy.cfg to support non-docker DNS

### DIFF
--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -6,6 +6,7 @@ global
 
 resolvers docker_resolver
     nameserver dns 127.0.0.11:53
+    parse-resolv-conf
     accepted_payload_size 8192
 
 defaults


### PR DESCRIPTION
In testing with podman, the local DNS entry is not on localhost. Allowing ha-proxy to parse `resolv.conf` has seemingly sorted this out.