### PR TITLE
Add `platform` parameter to avoid warnings on M1 Macs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -317,6 +317,7 @@ services:
       - "389:389/tcp"
 
   httpbin:
+    platform: linux/amd64
     networks:
       - kongpose-net
       - kongpose-net-internal
@@ -514,6 +515,7 @@ services:
     command: -f /mnt/locust/locustfile.py
 
   fake-smtp-server:
+    platform: linux/amd64
     networks:
       - kongpose-net
     image: reachfive/fake-smtp-server


### PR DESCRIPTION
Added the `platform: linux/amd64` parameter to a few services to stop the warnings received on M1 Macs when running compose up.